### PR TITLE
Wrap URL Request data with double quote instead of single quotes

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
+++ b/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
@@ -63,7 +63,7 @@ extension Snapshotting where Value == URLRequest, Format == String {
       var escapedBody = httpBody.replacingOccurrences(of: "\\\"", with: "\\\\\"")
       escapedBody = escapedBody.replacingOccurrences(of: "\"", with: "\\\"")
       
-      components.append("--data '\(escapedBody)'")
+      components.append("--data \"\(escapedBody)\"")
     }
     
     // Cookies


### PR DESCRIPTION
When snapshotting a post URLRequest that has a body which has been created by Codable, the cURL snapshot wraps the data in single quotes like this:

```
curl \
        --request POST \
        --header "Accept: application/json" \
        --header "Content-Type: application/json" \
        --data '{\"name\":\"tammy134235345235\", \"salary\":0, \"age\":\"tammy133\"}' \
        "http://dummy.restapiexample.com/api/v1/create"
```

Copying this cURL into terminal produces an invalid JSON error because the JSON is escaped incorrectly. Single quoted strings do not require escaping double quotes. Double quotes do. So then, I propose to make this change to double quote the body data similar to how the cookies section is quoted. This would transform the snapshot to this:

```
curl \
        --request POST \
        --header "Accept: application/json" \
        --header "Content-Type: application/json" \
        --data "{\"name\":\"tammy134235345235\", \"salary\":0, \"age\":\"tammy133\"}" \
        "http://dummy.restapiexample.com/api/v1/create"
```

Alternatively, we could choose to not escape the internal quotes, but that would make the code inconsistent with how cookies are represented.